### PR TITLE
test: use p-wait-for@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "github-generate-release": "latest",
     "nano-staged": "latest",
     "p-every": "latest",
+    "p-wait-for": "3",
     "pidtree": "latest",
     "ps-list": "7",
     "simple-git-hooks": "latest",

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,13 @@
 'use strict'
 
 const { setTimeout } = require('timers/promises')
+const pWaitFor = require('p-wait-for')
 const pidtree = require('pidtree')
 const pEvery = require('p-every')
 const psList = require('ps-list')
+const $ = require('tinyspawn')
 const path = require('path')
 const test = require('ava')
-const $ = require('tinyspawn')
 
 const scripts = {
   parent: path.join(__dirname, 'helpers', 'parent.js'),
@@ -20,20 +21,22 @@ const getProcess = async _pid =>
 
 const processExist = async pid => !!(await getProcess(pid))
 
-const waitFor = async (predicate, { timeout = 5000, interval = 100 } = {}) => {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < timeout) {
-    if (await predicate()) return true
-    await setTimeout(interval)
+const waitForPredicate = async predicate => {
+  try {
+    await pWaitFor(predicate, { timeout: 5000, interval: 100 })
+    return true
+  } catch (_) {
+    return false
   }
-  return predicate()
 }
 
 const waitForProcessExit = pid =>
-  waitFor(async () => !(await processExist(pid)))
+  waitForPredicate(async () => !(await processExist(pid)))
 
 const waitForProcessesExit = pids =>
-  waitFor(async () => pEvery(pids, async pid => !(await processExist(pid))))
+  waitForPredicate(async () =>
+    pEvery(pids, async pid => !(await processExist(pid)))
+  )
 
 const registerKillOnTeardown = (t, subprocess) => {
   t.teardown(async () => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change that swaps a local timeout/poll loop for `p-wait-for`, with minimal impact beyond potential test flakiness if timing behavior differs.
> 
> **Overview**
> Updates the test suite to use `p-wait-for@3` for waiting on process termination, replacing the bespoke `waitFor` polling loop with `waitForPredicate`.
> 
> Adds `p-wait-for` to devDependencies and adjusts test imports/usage accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9d12f46f63519a7b5e247b9c257575f459afaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->