### PR TITLE
chore: prefer execFile

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const { promisify } = require('util')
-const exec = promisify(require('child_process').exec)
+const execFile = promisify(require('child_process').execFile)
 
 const isWin = process.platform === 'win32'
 
 const win = async (subprocess, { signal = 'SIGKILL' } = {}) => {
   try {
-    await exec(`taskkill /pid ${subprocess.pid} /T /F`)
+    await execFile('taskkill', ['/pid', String(subprocess.pid), '/T', '/F'])
   } catch (_) {
     // taskkill can fail to kill the process e.g. due to missing permissions.
     // Let's kill the process via Node API. This delays killing of all child


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor of Windows process-kill path to avoid shell execution; behavior should be equivalent aside from argument parsing, with low functional risk.
> 
> **Overview**
> Switches the Windows `taskkill` invocation from `exec` (shell string) to `execFile` (argv array), passing the PID as an explicit argument.
> 
> This reduces reliance on shell parsing when terminating subprocess trees on Windows while keeping the existing fallback `subprocess.kill()` behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec2fba67bcf422c158fbab554aa60ac2a48e7610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->